### PR TITLE
feat: 动态处理icon类名

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -2,3 +2,9 @@
   from = "/*"
   to = "/index.html"
   status = 200
+[build]
+  command = "yarn run build"
+  publish = "dist"
+
+[build.environment]
+  NODE_VERSION = "22"

--- a/src/components/PlayerDrawer.vue
+++ b/src/components/PlayerDrawer.vue
@@ -547,7 +547,7 @@ const closeDrawer = () => {
     })
 
     tl.to(drawerRef.value, {
-      y: '-100%',
+      y: '100%',
       opacity: 0,
       duration: 0.4,
       ease: 'power3.in',

--- a/src/components/PlayerDrawer.vue
+++ b/src/components/PlayerDrawer.vue
@@ -877,7 +877,7 @@ onUnmounted(() => {
 
           <!-- 中心封面图片 - 绝对定位居中，75% = 288px -->
           <div
-            class="absolute top-1/2 left-1/2 h-full w-[65%] -translate-x-1/2 -translate-y-1/2 scale-80 cursor-pointer overflow-hidden rounded-full"
+            class="absolute top-1/2 left-1/2 aspect-square w-[65%] -translate-x-1/2 -translate-y-1/2 scale-80 cursor-pointer overflow-hidden rounded-full"
             @click="handleAlbumCoverClick"
           >
             <img

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,0 +1,27 @@
+// tailwind.config.ts
+// @ts-ignore
+import type { Config } from 'tailwindcss'
+
+const config: Config = {
+  content: ['./index.html', './src/**/*.{vue,js,ts,jsx,tsx}'],
+
+  theme: {
+    extend: {
+      // 主题扩展
+    },
+  },
+
+  // 处理动态类名
+  safelist: [
+    // 匹配 icon-[...] 格式的类名
+    { pattern: /icon-\[.+]/ },
+
+    // 其他，动态的颜色或背景色
+    // { pattern: /bg-(red|green|blue)-(100|200|300)/ },
+    // { pattern: /text-(xs|sm|lg|xl)/ },
+  ],
+
+  plugins: [],
+}
+
+export default config


### PR DESCRIPTION
## 通过Tailwind配置safelist解决动态拼接iconName的问题

- 描述：部分mdi图标`mdi--xxx`无法正常显示，Tailwind的即时编译器是静态扫描到的类名，`iconName`是通过js动态拼接的`icon-[...]`，所以在编译时无法生成对应的css代码。

- 解决方案之一（也可以在组件内手动添加映射的方式）：在`tailwind.config.ts`中配置`safelist`正则匹配到`icon-[...]`